### PR TITLE
buildgcc: Build GMP `--with-pic` if GCC defaults to `-pie`

### DIFF
--- a/util/crossgcc/buildgcc
+++ b/util/crossgcc/buildgcc
@@ -502,6 +502,13 @@ set_hostcflags_from_gmp() {
 }
 
 build_GMP() {
+	# Check if GCC enables `-pie` by default (possible since GCC 6).
+	# We need PIC in all static libraries then.
+	if "${CC}" -dumpspecs 2>/dev/null | grep -q '[{;][[:space:]]*:-pie\>'
+	then
+		OPTIONS="$OPTIONS --with-pic"
+	fi
+
 	CC="$CC" ../${GMP_DIR}/configure --disable-shared --enable-fat \
 		--prefix=$TARGETDIR $OPTIONS \
 		|| touch .failed


### PR DESCRIPTION
GCC 6 can optionally default to building all binaries as position
independent executables (PIE). This breaks linking against static
libraries that are compiled without position independent code (PIC).

Building GMP `--with-pic` in this case seems to be the least fragile
solution.

TEST=Run `make all` and `make BUILDGCC_OPTIONS=-b build-i386` in
     util/crossgcc on Debian Stretch.

Change-Id: I5f3185af9c8d599379a628e18724b217b88be974
Signed-off-by: Nico Huber <nico.huber@secunet.com>
Reviewed-on: https://review.coreboot.org/17936
Tested-by: build bot (Jenkins)
Reviewed-by: Paul Menzel <paulepanter@users.sourceforge.net>
Reviewed-by: Jonathan Neuschäfer <j.neuschaefer@gmx.net>